### PR TITLE
Remove pyfftw dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
     fi
   - conda config --add channels conda-forge
   - conda create -q -n testenv
-      python=$PYTHON_VERSION obspy pyfftw $GF $LP
+      python=$PYTHON_VERSION obspy $GF $LP
       pytest-cov
   - conda activate testenv
   - conda list

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Also, the following packages are required:
 
 - [`gfortran`](https://gcc.gnu.org/wiki/GFortran) (or any Fortran compiler)
 - [`obspy`](https://github.com/obspy/obspy/wiki)
-- [`pyfftw`](https://pyfftw.readthedocs.io/en/latest/)
 
 By  default, both `numpy` and `matplotlib` are installed as dependencies of `obspy`.
 
@@ -49,7 +48,7 @@ We recommend creating a custom
 where `telewavesim` can be installed along with its dependencies:
 
 ```bash
-conda create -n tws python=3.7 obspy pyfftw -c conda-forge
+conda create -n tws python=3.7 obspy -c conda-forge
 ```
 
 Activate the newly created environment:
@@ -70,7 +69,7 @@ cd Telewavesim
 
 ```bash
 pip install .
-``` 
+```
 
 ### Installing from Pypi
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'],
-    install_requires    = ['numpy>=1.15', 'obspy>=1.0.0', 'pyfftw>=0.11.1', 'matplotlib'],
+    install_requires    = ['numpy>=1.15', 'obspy>=1.0.0', 'matplotlib'],
     python_requires     = '>=3.5',
     tests_require       = ['pytest'],
     ext_modules         = ext,

--- a/telewavesim/__init__.py
+++ b/telewavesim/__init__.py
@@ -60,7 +60,6 @@ Also, the following packages are required:
 
 - ``gfortran`` (https://gcc.gnu.org/wiki/GFortran) (or any Fortran compiler)
 - ``obspy`` (https://github.com/obspy/obspy/wiki)
-- ``pyfftw`` (https://pyfftw.readthedocs.io/en/latest/)
 
 By  default, both ``numpy`` and ``matplotlib`` are installed as dependencies of ``obspy``. \
 See below for full installation details.
@@ -83,7 +82,7 @@ where ``telewavesim`` can be installed along with its dependencies.
 
 .. sourcecode:: bash
 
-   conda create -n tws python=3.7 obspy pyfftw -c conda-forge
+   conda create -n tws python=3.7 obspy -c conda-forge
 
 or create it from the ``tws_env.yml`` file:
 

--- a/telewavesim/tests/test_0_imports.py
+++ b/telewavesim/tests/test_0_imports.py
@@ -1,19 +1,9 @@
 def test_numpy_import():
     import numpy
 
-    return
-
 
 def test_obspy_import():
     import obspy
-
-    return
-
-
-def test_pyfftw_import():
-    import pyfftw
-
-    return
 
 
 def test_telewavesim_modules():

--- a/telewavesim/tests/test_notebooks.py
+++ b/telewavesim/tests/test_notebooks.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
 from pkg_resources import resource_filename
 import tempfile
 from os.path import join

--- a/telewavesim/tests/test_notebooks.py
+++ b/telewavesim/tests/test_notebooks.py
@@ -67,7 +67,7 @@ def test_Porter2011():
                           wvtype='P')
 
 
-def test_Autdet2016():
+def test_Audet2016():
     from obspy.core import Stream
     from obspy.signal.rotate import rotate_ne_rt
     from telewavesim import utils as ut

--- a/telewavesim/tests/test_routines.py
+++ b/telewavesim/tests/test_routines.py
@@ -2,9 +2,8 @@ from telewavesim import utils as ut
 from telewavesim.rmat_f import plane as pw_f
 from pkg_resources import resource_filename
 import numpy as np
-import pyfftw
+from numpy.fft import fft
 
-#from telewavesim.tests.conftest import load_params
 
 def test_plane_obs():
     modfile = resource_filename('telewavesim',
@@ -23,9 +22,9 @@ def test_plane_obs():
     ut.wave2for(dt, slow, baz)
     ut.obs2for(dp, c, rhof)
     yx, yy, yz = pw_f.plane_obs(npts, model.nlay, np.array(wvtype, dtype='c'))
-    ux = np.real(pyfftw.interfaces.numpy_fft.fft(yx))
-    uy = np.real(pyfftw.interfaces.numpy_fft.fft(yy))
-    uz = np.real(pyfftw.interfaces.numpy_fft.fft(yz))
+    ux = np.real(fft(yx))
+    uy = np.real(fft(yy))
+    uz = np.real(fft(yz))
 
     # seismogram should be maximized on vertical component
     assert np.max(np.abs(uz)) > np.max(np.abs(ux)) > np.max(np.abs(uy)), \
@@ -46,9 +45,9 @@ def test_plane_land():
     ut.model2for(model)
     ut.wave2for(dt, slow, baz)
     yx, yy, yz = pw_f.plane_land(npts, model.nlay, np.array(wvtype, dtype='c'))
-    ux = np.real(pyfftw.interfaces.numpy_fft.fft(yx))
-    uy = np.real(pyfftw.interfaces.numpy_fft.fft(yy))
-    uz = np.real(pyfftw.interfaces.numpy_fft.fft(yz))
+    ux = np.real(fft(yx))
+    uy = np.real(fft(yy))
+    uz = np.real(fft(yz))
 
     # seismogram should be maximized on vertical component
     assert np.max(np.abs(uz)) > np.max(np.abs(ux)) > np.max(np.abs(uy)), \

--- a/telewavesim/utils.py
+++ b/telewavesim/utils.py
@@ -27,7 +27,7 @@ Utility functions to interact with ``telewavesim`` modules.
 '''
 import itertools
 import numpy as np
-import pyfftw
+from numpy.fft import fft, fftshift, ifft
 from scipy.signal import hilbert
 from obspy.core import Trace, Stream
 from obspy.signal.rotate import rotate_ne_rt
@@ -772,9 +772,9 @@ def get_trxyz(yx, yy, yz, npts, dt, slow, baz, wvtype):
     """
 
     # Get displacements in time domain
-    ux = np.real(pyfftw.interfaces.numpy_fft.fft(yx))
-    uy = np.real(pyfftw.interfaces.numpy_fft.fft(yy))
-    uz = -np.real(pyfftw.interfaces.numpy_fft.fft(yz))
+    ux = np.real(fft(yx))
+    uy = np.real(fft(yy))
+    uz = -np.real(fft(yz))
 
     # Store in traces
     tux = Trace(data=ux)
@@ -829,39 +829,39 @@ def tf_from_xyz(trxyz, pvh=False, vp=None, vs=None):
 
         tfr = trV.copy(); tfr.data = np.zeros(len(tfr.data))
         tft = trH.copy(); tft.data = np.zeros(len(tft.data))
-        ftfv = pyfftw.interfaces.numpy_fft.fft(trV.data)
-        ftfh = pyfftw.interfaces.numpy_fft.fft(trH.data)
-        ftfp = pyfftw.interfaces.numpy_fft.fft(trP.data)
+        ftfv = fft(trV.data)
+        ftfh = fft(trH.data)
+        ftfp = fft(trP.data)
 
         if wvtype=='P':
             # Transfer function
-            tfr.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(ftfv,ftfp))))
-            tft.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(ftfh,ftfp))))
+            tfr.data = fftshift(np.real(ifft(np.divide(ftfv,ftfp))))
+            tft.data = fftshift(np.real(ifft(np.divide(ftfh,ftfp))))
         elif wvtype=='Si':
-            tfr.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfp,ftfv))))
-            tft.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfp,ftfh))))
+            tfr.data = fftshift(np.real(ifft(np.divide(-ftfp,ftfv))))
+            tft.data = fftshift(np.real(ifft(np.divide(-ftfp,ftfh))))
         elif wvtype=='SV':
-            tfr.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfp,ftfv))))
+            tfr.data = fftshift(np.real(ifft(np.divide(-ftfp,ftfv))))
         elif wvtype=='SH':
-            tft.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfp,ftfh))))
+            tft.data = fftshift(np.real(ifft(np.divide(-ftfp,ftfh))))
     else:
         tfr = rtr.copy(); tfr.data = np.zeros(len(tfr.data))
         tft = ttr.copy(); tft.data = np.zeros(len(tft.data))
-        ftfr = pyfftw.interfaces.numpy_fft.fft(rtr.data)
-        ftft = pyfftw.interfaces.numpy_fft.fft(ttr.data)
-        ftfz = pyfftw.interfaces.numpy_fft.fft(ztr.data)
+        ftfr = fft(rtr.data)
+        ftft = fft(ttr.data)
+        ftfz = fft(ztr.data)
 
         if wvtype=='P':
             # Transfer function
-            tfr.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(ftfr,ftfz))))
-            tft.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(ftft,ftfz))))
+            tfr.data = fftshift(np.real(ifft(np.divide(ftfr,ftfz))))
+            tft.data = fftshift(np.real(ifft(np.divide(ftft,ftfz))))
         elif wvtype=='Si':
-            tfr.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfz,ftfr))))
-            tft.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfz,ftft))))
+            tfr.data = fftshift(np.real(ifft(np.divide(-ftfz,ftfr))))
+            tft.data = fftshift(np.real(ifft(np.divide(-ftfz,ftft))))
         elif wvtype=='SV':
-            tfr.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfz,ftfr))))
+            tfr.data = fftshift(np.real(ifft(np.divide(-ftfz,ftfr))))
         elif wvtype=='SH':
-            tft.data = np.fft.fftshift(np.real(pyfftw.interfaces.numpy_fft.ifft(np.divide(-ftfz,ftft))))
+            tft.data = fftshift(np.real(ifft(np.divide(-ftfz,ftft))))
 
     # Store in stream
     tfs = Stream(traces=[tfr, tft])


### PR DESCRIPTION
This PR would remove the dependency on pyfftw and replaces its function by the corresponding numpy functions. The test cases run as fast as before. If the user wants to use pyfftw for a possible speedup he can use this code snippets before importing telewavesim:

```py
import numpy
import pyfftw
numpy.fft = pyfftw.interfaces.numpy_fft
import telewavesim
```