### PR TITLE
add python3.5 to travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       env: PYTHON_VERSION=3.7
 
 before_install:
+  - export NPY_DISTUTILS_APPEND_FLAGS=1
   - wget https://raw.githubusercontent.com/trichter/conda4travis/latest/conda4travis.sh -O conda4travis.sh
   - source conda4travis.sh
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,9 @@ before_install:
   - export NPY_DISTUTILS_APPEND_FLAGS=1
   - wget https://raw.githubusercontent.com/trichter/conda4travis/latest/conda4travis.sh -O conda4travis.sh
   - source conda4travis.sh
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      GF="gfortran_osx-64";
-    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      GF="gfortran_linux-64";
-    fi
   - conda config --add channels conda-forge
   - conda create -q -n testenv
-      python=$PYTHON_VERSION obspy $GF "numpy>=1.15"
+      python=$PYTHON_VERSION obspy "gfortran_${TRAVIS_OS_NAME}-64" "numpy>=1.15"
       pytest-cov
   - conda activate testenv
   - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ sudo: false
 matrix:
   include:
     - os: linux
+      env: PYTHON_VERSION=3.5
+    - os: linux
       env: PYTHON_VERSION=3.6
     - os: linux
       env: PYTHON_VERSION=3.7
+    - os: osx
+      env: PYTHON_VERSION=3.5
     - os: osx
       env: PYTHON_VERSION=3.6
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     fi
   - conda config --add channels conda-forge
   - conda create -q -n testenv
-      python=$PYTHON_VERSION obspy $GF
+      python=$PYTHON_VERSION obspy $GF "numpy>=1.15"
       pytest-cov
   - conda activate testenv
   - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       GF="gfortran_osx-64";
     elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      GF="gfortran_linux-64"; LP='lapack';
+      GF="gfortran_linux-64";
     fi
   - conda config --add channels conda-forge
   - conda create -q -n testenv
-      python=$PYTHON_VERSION obspy $GF $LP
+      python=$PYTHON_VERSION obspy $GF
       pytest-cov
   - conda activate testenv
   - conda list

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ workflows are covered in the Jupyter notebooks bundled with this package.
 
 ### Dependencies
 
-The current version was developed using **Python3.7**
+The current version can be used with Python version 3.5 and above.
 Also, the following packages are required:
 
 - [`gfortran`](https://gcc.gnu.org/wiki/GFortran) (or any Fortran compiler)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os.path
-import platform
 import re
 from numpy.distutils.core import setup, Extension
 
@@ -14,25 +13,9 @@ def find_version(*paths):
     raise RuntimeError("Unable to find version string.")
 
 
-if platform.system() == 'Linux':
-    # this hack hopefully  will become unecessary in the future
-    # see issue #2
-    # ci fail: https://travis-ci.org/trichter/Telewavesim/builds/594469551
-    from numpy import __config__
-    attrs = ['blas_mkl_info', 'blas_opt_info', 'lapack_mkl_info',
-             'lapack_opt_info', 'openblas_lapack_info']
-    libdirs = set()
-    for attr in attrs:
-        obj = getattr(__config__, attr, {}).get('library_dirs')
-        if obj is not None:
-            libdirs.update(obj)
-    ext_kw = dict(library_dirs=list(libdirs), libraries=['lapack'])
-else:
-    ext_kw = {}
-
 ext = [Extension(name='telewavesim.rmat_f',
                  sources=['src/rmat.f90', 'src/rmat_sub.f90'],
-                 **ext_kw)]
+                 libraries=['lapack'])]
 
 setup(
     name                = 'telewavesim',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     maintainer          = 'Pascal Audet',
     author_email        = 'pascal.audet@uottawa.ca',
     url                 = 'https://github.com/paudetseis/Telewavesim',
-    download_url        = 'https://github.com/paudetseis/Telewavesim/archive/0.1.0.tar.gz',
     classifiers         = [
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -18,26 +18,26 @@ ext = [Extension(name='telewavesim.rmat_f',
                  libraries=['lapack'])]
 
 setup(
-    name                = 'telewavesim',
-    version             = find_version('telewavesim', '__init__.py'),
-    description         = 'Python package for teleseismic body-wave modeling',
-    author              = 'Pascal Audet, Colin J. Thomson, Michael G. Bostock',
-    maintainer          = 'Pascal Audet',
-    author_email        = 'pascal.audet@uottawa.ca',
-    url                 = 'https://github.com/paudetseis/Telewavesim',
-    classifiers         = [
+    name='telewavesim',
+    version=find_version('telewavesim', '__init__.py'),
+    description='Python package for teleseismic body-wave modeling',
+    author='Pascal Audet, Colin J. Thomson, Michael G. Bostock',
+    maintainer='Pascal Audet',
+    author_email='pascal.audet@uottawa.ca',
+    url='https://github.com/paudetseis/Telewavesim',
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Fortran',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'],
-    install_requires    = ['numpy>=1.15', 'obspy>=1.0.0', 'matplotlib'],
-    python_requires     = '>=3.5',
-    tests_require       = ['pytest'],
-    ext_modules         = ext,
-    packages            = ['telewavesim', 'telewavesim.tests'],
-    package_data        = {
+    install_requires=['numpy>=1.15', 'obspy>=1.0.0', 'matplotlib'],
+    python_requires='>=3.5',
+    tests_require=['pytest'],
+    ext_modules=ext,
+    packages=['telewavesim', 'telewavesim.tests'],
+    package_data={
         'telewavesim': [
             'examples/*.ipynb',
             'examples/models/*.txt',

--- a/telewavesim/tests/test_0_imports.py
+++ b/telewavesim/tests/test_0_imports.py
@@ -10,6 +10,8 @@ def test_telewavesim_modules():
     import telewavesim
     from telewavesim import elast
     from telewavesim import utils
+    import matplotlib
+    matplotlib.use('Agg')
     from telewavesim import wiggle
     from telewavesim.rmat_f import conf
     from telewavesim.rmat_f import plane

--- a/telewavesim/tests/test_notebooks.py
+++ b/telewavesim/tests/test_notebooks.py
@@ -26,6 +26,8 @@ from os.path import join
 
 
 def test_Porter2011():
+    import matplotlib
+    matplotlib.use('Agg')
     import numpy as np
     from obspy.core import Stream
     from telewavesim import utils as ut
@@ -68,6 +70,8 @@ def test_Porter2011():
 
 
 def test_Audet2016():
+    import matplotlib
+    matplotlib.use('Agg')
     from obspy.core import Stream
     from obspy.signal.rotate import rotate_ne_rt
     from telewavesim import utils as ut
@@ -109,6 +113,8 @@ def test_Audet2016():
 
 
 def test_SKS():
+    import matplotlib
+    matplotlib.use('Agg')
     import numpy as np
     from obspy.core import Stream
     from obspy.signal.rotate import rotate_ne_rt

--- a/telewavesim/tests/test_notebooks.py
+++ b/telewavesim/tests/test_notebooks.py
@@ -46,7 +46,8 @@ def test_Porter2011():
     # Loop over range of data
     for bb in baz:
         # Calculate the plane waves seismograms
-        trxyz = ut.run_plane(model, slow, npts, dt, bb, wvtype=wvtype, obs=False)
+        trxyz = ut.run_plane(model, slow, npts, dt, bb, wvtype=wvtype,
+                             obs=False)
         # Then the transfer functions in Z-R-T coordinate system
         tfs = ut.tf_from_xyz(trxyz, pvh=False)
         # Append to streams
@@ -65,7 +66,6 @@ def test_Porter2011():
         wg.rf_wiggles_baz(trR, trT, trR_stack, trT_stack, 'test', btyp='baz',
                           scale=1.e3, tmin=-5., tmax=8., save=True,
                           ftitle=join(tempdir, 'porter2011.png'),
-#                          ftitle='porter2011',
                           wvtype='P')
 
 
@@ -85,7 +85,8 @@ def test_Audet2016():
     c = 1.500    # P-wave velocity in salt water (km/s)
     rhof = 1027.  # Density of salt water (kg/m^3)
     slow = 0.06  # Horizontal slowness (or ray parameter) in s/km
-    # Back-azimuth direction in degrees (has no influence if model is isotropic)
+    # Back-azimuth direction in degrees
+    # (has no influence if model is isotropic)
     baz = 0.
     model = ut.read_model(modfile)
     assert list(model.rho) == [2800.0, 2800.0, 3200.0]
@@ -108,7 +109,6 @@ def test_Audet2016():
     with tempfile.TemporaryDirectory() as tempdir:
         wg.pw_wiggles_Audet2016(strf, t1=t1, tmax=10., f1=f1, f2=f2,
                                 ftitle=join(tempdir, 'audet2016'),
-#                                ftitle='audet2016',
                                 scale=2.e-7, save=True)
 
 
@@ -161,5 +161,4 @@ def test_SKS():
         wg.pw_wiggles_baz(trR, trT, 'test', btyp='baz', scale=0.05,
                           t1=t1, tmin=0., tmax=40, save=True,
                           ftitle=join(tempdir, 'sks'),
-#                          ftitle='sks',
                           wvtype='SV')


### PR DESCRIPTION
This PR adds support for python3.5 on travis. It also removes the previously needed lapack work-around. Fixes #2 and #10.