### PR TITLE
fix typo in __init__.py

### DIFF
--- a/telewavesim/__init__.py
+++ b/telewavesim/__init__.py
@@ -247,7 +247,7 @@ This flag should be set to the specific single-crystal or rock
 abbreviation, for which the elastic properties have been determined 
 in the lab. Currently available options are:
 
-.. sourcecode::python
+.. sourcecode:: python
 
    mins = ['atg', 'bt', 'cpx', 'dol', 'ep', 'grt', 'gln', 'hbl', 'jade', \
            'lws', 'lz', 'ms', 'ol', 'opx', 'plag', 'qtz', 'zo']


### PR DESCRIPTION
This PR fixes a small typo in __init__.py that prevented lines of source code from showing in the html.