### PR TITLE
increased max # layers to 100 in fortran source code

### DIFF
--- a/src/rmat.f90
+++ b/src/rmat.f90
@@ -34,7 +34,7 @@
       IMPLICIT NONE
 
       DOUBLE PRECISION, PARAMETER :: pi = 3.141592653589793d0
-      INTEGER, PARAMETER :: nlaymx = 30
+      INTEGER, PARAMETER :: nlaymx = 100
 !
 ! Model parameters
 !


### PR DESCRIPTION
This quick PR increases the maximum number of layers in the definition of seismic velocity models to 100. This is hard coded in the code rmat.f90.